### PR TITLE
Jay/requirement routing

### DIFF
--- a/src/app/api/requirements/route.ts
+++ b/src/app/api/requirements/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import path from 'path';
+import fs from 'fs/promises';
+
+interface Requirement {
+    requirementId: number;
+    requirementName: string;
+    requirementDesc: string;
+    promptText: string;
+    supplementaryInfo: string;
+    outputType: OutputType;
+}
+
+interface RequirementFormData {
+    requirementName: string;
+    requirementDesc: string;
+    promptText: string;
+    supplementaryInfo: string;
+    outputType: OutputType;
+}
+
+export type OutputType = 'boolean' | 'number' | 'decimal' | 'date' | 'currency' | 'text';
+
+export async function POST(request: NextRequest) {
+    try {
+        const requirementData: RequirementFormData = await request.json();
+        
+        const filePath = path.join(process.cwd(), 'src', 'app', 'test_data', 'requirement_test_data.json');
+        
+        // Read existing requirements
+        let requirements: Requirement[] = [];
+        const data = await fs.readFile(filePath, 'utf-8');
+        requirements = JSON.parse(data);
+      
+        // Create new requirement from form.
+        const requirement: Requirement = {
+            requirementId: requirements.length,
+            ...requirementData
+        };
+        requirements.push(requirement);
+        
+        // Ensure directory exists
+        await fs.mkdir(path.dirname(filePath), { recursive: true });
+        
+        // Save to file
+        await fs.writeFile(filePath, JSON.stringify(requirements, null, 2));
+        
+        return NextResponse.json({ 
+            success: true, 
+            requirement,
+            message: 'Requirement saved successfully'
+        });
+        
+    } catch (error) {
+        console.error('Error saving requirement:', error);
+        return NextResponse.json(
+            { error: 'Failed to save requirement' },
+            { status: 500 }
+        );
+    }
+}
+
+export async function GET() {
+    try {
+        const filePath = path.join(process.cwd(), 'data', 'requirements.json');
+        const data = await fs.readFile(filePath, 'utf-8');
+        const requirements = JSON.parse(data);
+        
+        return NextResponse.json({ requirements });
+    } catch (error) {
+        // File doesn't exist or other error
+        return NextResponse.json({ requirements: [] });
+    }
+}

--- a/src/app/api/requirements/route.ts
+++ b/src/app/api/requirements/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: NextRequest) {
       
         // Create new requirement from form.
         const requirement: Requirement = {
-            requirementId: requirements.length,
+            requirementId: requirements.length + 1,
             ...requirementData
         };
         requirements.push(requirement);
@@ -57,18 +57,5 @@ export async function POST(request: NextRequest) {
             { error: 'Failed to save requirement' },
             { status: 500 }
         );
-    }
-}
-
-export async function GET() {
-    try {
-        const filePath = path.join(process.cwd(), 'data', 'requirements.json');
-        const data = await fs.readFile(filePath, 'utf-8');
-        const requirements = JSON.parse(data);
-        
-        return NextResponse.json({ requirements });
-    } catch (error) {
-        // File doesn't exist or other error
-        return NextResponse.json({ requirements: [] });
     }
 }

--- a/src/app/assessments/details/[assessment_id]/page.tsx
+++ b/src/app/assessments/details/[assessment_id]/page.tsx
@@ -36,8 +36,8 @@ export default async function AssessmentDetail({params,}: { params: { assessment
         <h2 className="font-semibold">Results</h2>
         <ul className="border p-4 space-y-2">
           {assessment.results.map((result) => (
-            <li key={result.requirement_id} className="flex justify-between">
-              <span>{result.requirement_name}</span>
+            <li key={result.requirementId} className="flex justify-between">
+              <span>{result.requirementName}</span>
               <span>{result.passed ? '✅ Pass' : '❌ Fail'}</span>
             </li>
           ))}

--- a/src/app/frameworks/builder/requirements/page.tsx
+++ b/src/app/frameworks/builder/requirements/page.tsx
@@ -1,6 +1,31 @@
+'use client';
+
+import { OutputType } from "@/app/api/requirements/route";
 import Link from "next/link";
+import { useState } from 'react';
+import { saveRequirement } from "@/utils/requirements";
 
 export default function RequirementEditor() {
+
+  const [formData, setFormData] = useState({
+    requirementName: '',
+    requirementDesc: '',
+    promptText: '',
+    supplementaryInfo: '',
+    outputType: 'boolean' as OutputType
+  });
+
+  const handleInputChange = (field) => (e) => {
+    setFormData(prev => ({
+      ...prev,
+      [field]: e.target.value
+    }));
+  };
+
+  const saveRequirementForm = () => {
+    saveRequirement(formData);
+  };
+
   return (
     <div className="p-8 space-y-8">
       <div>
@@ -19,7 +44,18 @@ export default function RequirementEditor() {
         <label className="block" title="A short title for this requirement">
           Title
         </label>
-        <input className="border w-full" placeholder="Requirement title" />
+        <input className="border w-full"    placeholder="Requirement title"
+          value={formData.requirementName} onChange={handleInputChange('requirementName')}
+        />
+      </div>
+
+      <div>
+        <label className="block" title="A brief description of this requirement">
+          Description
+        </label>
+        <input className="border w-full" placeholder="Requirement description"
+          value={formData.requirementDesc} onChange={handleInputChange('requirementDesc')}
+        />
       </div>
 
       <div>
@@ -32,6 +68,7 @@ export default function RequirementEditor() {
         <textarea
           className="border w-full"
           placeholder="Enter the exact check or question here"
+          value={formData.promptText} onChange={handleInputChange('promptText')}
         />
       </div>
 
@@ -45,6 +82,7 @@ export default function RequirementEditor() {
         <textarea
           className="border w-full"
           placeholder="Optional supporting info"
+          value={formData.supplementaryInfo} onChange={handleInputChange('supplementaryInfo')}
         />
       </div>
 
@@ -55,7 +93,7 @@ export default function RequirementEditor() {
         >
           Output Type
         </label>
-        <select className="border w-full">
+        <select className="border w-full" value={formData.outputType} onChange={handleInputChange('outputType')}>
           <option value="boolean">True / False</option>
           <option value="number">Whole Number</option>
           <option value="decimal">Decimal Number</option>
@@ -68,6 +106,7 @@ export default function RequirementEditor() {
       <div className="flex space-x-4">
         <Link
           href="/frameworks/builder"
+          onClick={saveRequirementForm}
           className="border px-4 py-2"
           title="Go back without saving"
         >

--- a/src/app/frameworks/builder/requirements/page.tsx
+++ b/src/app/frameworks/builder/requirements/page.tsx
@@ -3,7 +3,14 @@
 import { OutputType } from "@/app/api/requirements/route";
 import Link from "next/link";
 import { useState } from 'react';
-import { saveRequirement } from "@/utils/requirements";
+
+interface RequirementFormData {
+    requirementName: string;
+    requirementDesc: string;
+    promptText: string;
+    supplementaryInfo: string;
+    outputType: OutputType;
+}
 
 export default function RequirementEditor() {
 
@@ -122,4 +129,27 @@ export default function RequirementEditor() {
       </div>
     </div>
   );
+}
+
+export async function saveRequirement(requirementData: RequirementFormData) {
+    try {
+        const response = await fetch('/api/requirements', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(requirementData),
+        });
+        
+        console.log(response);
+        if (!response.ok) {
+            throw new Error('Failed to save requirement');
+        }
+        
+        const result = await response.json();
+        return result;
+    } catch (error) {
+        console.error('Error saving requirement:', error);
+        throw error;
+    }
 }

--- a/src/app/frameworks/builder/requirements/page.tsx
+++ b/src/app/frameworks/builder/requirements/page.tsx
@@ -22,7 +22,9 @@ export default function RequirementEditor() {
     outputType: 'boolean' as OutputType
   });
 
-  const handleInputChange = (field) => (e) => {
+  const handleInputChange = (field: keyof RequirementFormData) => (
+    e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
+  ) => {
     setFormData(prev => ({
       ...prev,
       [field]: e.target.value

--- a/src/app/frameworks/details/[framework_id]/page.tsx
+++ b/src/app/frameworks/details/[framework_id]/page.tsx
@@ -30,9 +30,9 @@ export default async function frameworkDetail({params,}: { params: { framework_i
         <h2 className="font-semibold">Results</h2>
         <ul className="border p-4 space-y-2">
           {framework.requirements.map((result) => (
-            <li key={result.requirement_id} className="flex justify-between">
-              <span>{result.requirement_name}</span>
-              <span>{result.requirement_desc}</span>
+            <li key={result.requirementId} className="flex justify-between">
+              <span>{result.requirementName}</span>
+              <span>{result.requirementDesc}</span>
             </li>
           ))}
         </ul>

--- a/src/app/frameworks/page.tsx
+++ b/src/app/frameworks/page.tsx
@@ -1,9 +1,8 @@
 import Link from "next/link";
-import { getFramework } from "@/utils/frameworks";
+import { getFrameworks } from "@/utils/frameworks";
 
 export default async function Frameworks() {
-  const frameworks = [getFramework(1), getFramework(2)];
-  const frameworkData = await Promise.all(frameworks);
+  const frameworkData = await getFrameworks();
 
   function renderFramework(framework: { id: number; name: string; description: string }) {
     return (

--- a/src/app/test_data/assessment_test_data.json
+++ b/src/app/test_data/assessment_test_data.json
@@ -7,13 +7,13 @@
     "summary": "The document was up to par in several areas such as ....",
     "results": [
       {
-        "requirement_id": 1,
-        "requirement_name": "Requirement 1",
+        "requirementId": 1,
+        "requirementName": "Requirement 1",
         "passed": true
       },
       {
-        "requirement_id": 2,
-        "requirement_name": "Requirement 2",
+        "requirementId": 2,
+        "requirementName": "Requirement 2",
         "passed": false
       }
     ]
@@ -26,18 +26,18 @@
     "summary": "Strong performance in communication areas with room for improvement in technical specifications ....",
     "results": [
       {
-        "requirement_id": 1,
-        "requirement_name": "Requirement 1",
+        "requirementId": 1,
+        "requirementName": "Requirement 1",
         "passed": true
       },
       {
-        "requirement_id": 2,
-        "requirement_name": "Requirement 2",
+        "requirementId": 2,
+        "requirementName": "Requirement 2",
         "passed": true
       },
       {
-        "requirement_id": 3,
-        "requirement_name": "Requirement 3",
+        "requirementId": 3,
+        "requirementName": "Requirement 3",
         "passed": false
       }
     ]

--- a/src/app/test_data/framework_test_data.json
+++ b/src/app/test_data/framework_test_data.json
@@ -5,14 +5,14 @@
     "description": "Description for Hugh Jackman Letter Assessment",
     "requirements": [
       {
-        "requirement_id": 1,
-        "requirement_name": "Requirement 1",
-        "requirement_desc": "This is the description for requirement 1"
+        "requirementId": 1,
+        "requirementName": "Requirement 1",
+        "requirementDesc": "This is the description for requirement 1"
       },
       {
-        "requirement_id": 2,
-        "requirement_name": "Requirement 2",
-        "requirement_desc": "This is the description for requirement 2"
+        "requirementId": 2,
+        "requirementName": "Requirement 2",
+        "requirementDesc": "This is the description for requirement 2"
       }
     ]
   },
@@ -23,19 +23,19 @@
     "framework": "Framework to access a document type",
     "requirements": [
       {
-        "requirement_id": 1,
-        "requirement_name": "Requirement 1",
-        "requirement_desc": "This is the description for requirement 1"
+        "requirementId": 1,
+        "requirementName": "Requirement 1",
+        "requirementDesc": "This is the description for requirement 1"
       },
       {
-        "requirement_id": 2,
-        "requirement_name": "Requirement 2",
-        "requirement_desc": "This is the description for requirement 2"
+        "requirementId": 2,
+        "requirementName": "Requirement 2",
+        "requirementDesc": "This is the description for requirement 2"
       },
       {
-        "requirement_id": 3,
-        "requirement_name": "Requirement 3",
-        "requirement_desc": "This is the description for requirement 3"
+        "requirementId": 3,
+        "requirementName": "Requirement 3",
+        "requirementDesc": "This is the description for requirement 3"
       }
     ]
   }

--- a/src/app/test_data/requirement_test_data.json
+++ b/src/app/test_data/requirement_test_data.json
@@ -1,0 +1,26 @@
+[
+  {
+    "requirementId": 1,
+    "requirementName": "Requirement 1",
+    "requirementDesc": "This is the description for requirement 1",
+    "prompt_text": "Please evaluate the document based on requirement 1.",
+    "supplementaryInfo": "Additional context or guidelines for requirement 1.",
+    "outputType": "boolean"
+  },
+  {
+    "requirementId": 2,
+    "requirementName": "Requirement 2",
+    "requirementDesc": "This is the description for requirement 2",
+    "prompt_text": "Please evaluate the document based on requirement 2.",
+    "supplementaryInfo": "Additional context or guidelines for requirement 2.",
+    "outputType": "text"
+  },
+  {
+    "requirementId": 3,
+    "requirementName": "Requirement 3",
+    "requirementDesc": "This is the description for requirement 3",
+    "prompt_text": "Please evaluate the document based on requirement 3.",
+    "supplementaryInfo": "Additional context or guidelines for requirement 3.",
+    "outputType": "number"
+  }
+]

--- a/src/utils/assessments.tsx
+++ b/src/utils/assessments.tsx
@@ -31,3 +31,11 @@ export async function getAssessment(id: number): Promise<Assessment> {
   }
   return assessment;
 }
+
+export async function getAssessments(): Promise<Assessment[]> {
+  // Read the JSON file
+  const filePath = path.join(process.cwd(), 'src', 'app', 'test_data', 'assessment_test_data.json');
+  const fileContents = await fs.readFile(filePath, 'utf8');
+  const assessments: Assessment[] = JSON.parse(fileContents);
+  return assessments;
+}

--- a/src/utils/assessments.tsx
+++ b/src/utils/assessments.tsx
@@ -2,8 +2,8 @@ import path from 'path';
 import fs from 'fs/promises';
 
 interface AssessmentResult {
-  requirement_id: number;
-  requirement_name: string;
+  requirementId: number;
+  requirementName: string;
   passed: boolean;
 }
 

--- a/src/utils/frameworks.tsx
+++ b/src/utils/frameworks.tsx
@@ -7,7 +7,7 @@ interface FrameworkRequirement {
   requirementDesc: string;
 }
 
-interface Framework {
+export interface Framework {
   id: number;
   name: string;
   description: string;

--- a/src/utils/frameworks.tsx
+++ b/src/utils/frameworks.tsx
@@ -2,9 +2,9 @@ import path from 'path';
 import fs from 'fs/promises';
 
 interface FrameworkRequirement {
-  requirement_id: number;
-  requirement_name: string;
-  requirement_desc: string;
+  requirementId: number;
+  requirementName: string;
+  requirementDesc: string;
 }
 
 interface Framework {

--- a/src/utils/frameworks.tsx
+++ b/src/utils/frameworks.tsx
@@ -28,3 +28,11 @@ export async function getFramework(id: number): Promise<Framework> {
   }
   return framework;
 }
+
+export async function getFrameworks(): Promise<Framework[]> {
+  // Read the JSON file
+  const filePath = path.join(process.cwd(), 'src', 'app', 'test_data', 'framework_test_data.json');
+  const fileContents = await fs.readFile(filePath, 'utf8');
+  const frameworks: Framework[] = JSON.parse(fileContents);
+  return frameworks;
+}   

--- a/src/utils/requirements.tsx
+++ b/src/utils/requirements.tsx
@@ -1,6 +1,18 @@
+import path from 'path';
+import fs from 'fs/promises';
+
 export type OutputType = 'boolean' | 'number' | 'decimal' | 'date' | 'currency' | 'text';
 
 interface RequirementFormData {
+    requirementName: string;
+    requirementDesc: string;
+    promptText: string;
+    supplementaryInfo: string;
+    outputType: OutputType;
+}
+
+interface Requirement {
+    requirementId: number;
     requirementName: string;
     requirementDesc: string;
     promptText: string;
@@ -31,14 +43,25 @@ export async function saveRequirement(requirementData: RequirementFormData) {
     }
 }
 
-// Optional: Add function to get requirements
-export async function getRequirements() {
-    try {
-        const response = await fetch('/api/requirements');
-        const result = await response.json();
-        return result.requirements;
-    } catch (error) {
-        console.error('Error fetching requirements:', error);
-        return [];
-    }
+export async function getRequirement(id: number): Promise<Requirement> {
+  // Read the JSON file
+  const filePath = path.join(process.cwd(), 'src', 'app', 'test_data', 'requirement_test_data.json');
+  const fileContents = await fs.readFile(filePath, 'utf8');
+  const requirements: Requirement[] = JSON.parse(fileContents);
+
+  // Find the requirement with the matching id
+  const requirement = requirements.find(r => r.requirementId === id);
+
+  if (!requirement) {
+    throw new Error(`Requirement with id ${id} not found`);
+  }
+  return requirement;
+}
+
+export async function getRequirements(): Promise<Requirement[]> {
+  // Read the JSON file
+  const filePath = path.join(process.cwd(), 'src', 'app', 'test_data', 'requirement_test_data.json');
+  const fileContents = await fs.readFile(filePath, 'utf8');
+  const requirements: Requirement[] = JSON.parse(fileContents);
+  return requirements;
 }

--- a/src/utils/requirements.tsx
+++ b/src/utils/requirements.tsx
@@ -3,14 +3,6 @@ import fs from 'fs/promises';
 
 export type OutputType = 'boolean' | 'number' | 'decimal' | 'date' | 'currency' | 'text';
 
-interface RequirementFormData {
-    requirementName: string;
-    requirementDesc: string;
-    promptText: string;
-    supplementaryInfo: string;
-    outputType: OutputType;
-}
-
 interface Requirement {
     requirementId: number;
     requirementName: string;
@@ -18,29 +10,6 @@ interface Requirement {
     promptText: string;
     supplementaryInfo: string;
     outputType: OutputType;
-}
-
-export async function saveRequirement(requirementData: RequirementFormData) {
-    try {
-        const response = await fetch('/api/requirements', {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(requirementData),
-        });
-        
-        console.log(response);
-        if (!response.ok) {
-            throw new Error('Failed to save requirement');
-        }
-        
-        const result = await response.json();
-        return result;
-    } catch (error) {
-        console.error('Error saving requirement:', error);
-        throw error;
-    }
 }
 
 export async function getRequirement(id: number): Promise<Requirement> {

--- a/src/utils/requirements.tsx
+++ b/src/utils/requirements.tsx
@@ -1,0 +1,44 @@
+export type OutputType = 'boolean' | 'number' | 'decimal' | 'date' | 'currency' | 'text';
+
+interface RequirementFormData {
+    requirementName: string;
+    requirementDesc: string;
+    promptText: string;
+    supplementaryInfo: string;
+    outputType: OutputType;
+}
+
+export async function saveRequirement(requirementData: RequirementFormData) {
+    try {
+        const response = await fetch('/api/requirements', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify(requirementData),
+        });
+        
+        console.log(response);
+        if (!response.ok) {
+            throw new Error('Failed to save requirement');
+        }
+        
+        const result = await response.json();
+        return result;
+    } catch (error) {
+        console.error('Error saving requirement:', error);
+        throw error;
+    }
+}
+
+// Optional: Add function to get requirements
+export async function getRequirements() {
+    try {
+        const response = await fetch('/api/requirements');
+        const result = await response.json();
+        return result.requirements;
+    } catch (error) {
+        console.error('Error fetching requirements:', error);
+        return [];
+    }
+}


### PR DESCRIPTION
Added client-side routing to let us post a new requirement to the JSON. We can add this for assessments and frameworks soon too.

Set up code to fetch all assessments/frameworks/requirements or just one by ID. 